### PR TITLE
Feature/tests categories

### DIFF
--- a/kaigara.gemspec
+++ b/kaigara.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "byebug", "~> 9"
 end

--- a/spec/fixtures/refops/operations/02_template.rb
+++ b/spec/fixtures/refops/operations/02_template.rb
@@ -1,0 +1,5 @@
+## Created on 2016/07/07
+
+template('script.pl', 'resources/script.pl')
+template('script.rb', 'resources/script.rb')
+template('script.sh', 'resources/script.sh')

--- a/spec/integration/system_spec.rb
+++ b/spec/integration/system_spec.rb
@@ -1,6 +1,6 @@
 require_relative "spec_helper"
 
-describe "operations on any OS" do
+describe "operations on any OS", :integration do
   let(:sysops) { Kaigara::Sysops.new }
 
   describe 'exec' do

--- a/spec/kaigara_spec.rb
+++ b/spec/kaigara_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Kaigara do
+describe Kaigara, :unit do
   it 'has a version number' do
     expect(Kaigara::VERSION).not_to be nil
   end

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Kaigara::Metadata do
+describe Kaigara::Metadata, :unit do
   before(:each) do
     @md = Kaigara::Metadata.new do |c|
       c.var = 'var'

--- a/spec/operations_spec.rb
+++ b/spec/operations_spec.rb
@@ -1,0 +1,33 @@
+require_relative 'spec_helper'
+
+describe 'operations' do
+  include TmpDirIsolation
+
+  let(:sysops_task) { Kaigara::Sysops }
+
+  before(:each) do
+    FileUtils.cp_r(fixture("refops"), ".")
+    Dir.chdir "refops"
+  end
+
+  describe "script" do
+    it 'generate and run any script' do
+      expect { sysops_task.start(["exec", "01_script"]) }.to output(/perl/).to_stdout
+      expect { sysops_task.start(["exec", "01_script"]) }.to output(/bash/).to_stdout
+      expect { sysops_task.start(["exec", "01_script"]) }.to output(/ruby/).to_stdout
+    end
+  end
+
+  describe "template" do
+    it "generate files from templates" do
+      sysops_task.start(["exec", "02_template"])
+      expect(File).to exist("resources/script.pl")
+      expect(File).to exist("resources/script.rb")
+      expect(File).to exist("resources/script.sh")
+
+      expect(`perl resources/script.pl`).to include("perl")
+      expect(`ruby resources/script.rb`).to include("ruby")
+      expect(`bash resources/script.sh`).to include("bash")
+    end
+  end
+end

--- a/spec/operations_spec.rb
+++ b/spec/operations_spec.rb
@@ -1,6 +1,6 @@
 require_relative 'spec_helper'
 
-describe 'operations' do
+describe 'operations', :unit do
   include TmpDirIsolation
 
   let(:sysops_task) { Kaigara::Sysops }

--- a/spec/operations_spec.rb
+++ b/spec/operations_spec.rb
@@ -4,6 +4,7 @@ describe 'operations', :unit do
   include TmpDirIsolation
 
   let(:sysops_task) { Kaigara::Sysops }
+  let(:sysops) { sysops_task.new }
 
   before(:each) do
     FileUtils.cp_r(fixture("refops"), ".")
@@ -11,10 +12,22 @@ describe 'operations', :unit do
   end
 
   describe "script" do
-    it 'generate and run any script' do
+    it 'generates and runs scripts' do
       expect { sysops_task.start(["exec", "01_script"]) }.to output(/perl/).to_stdout
       expect { sysops_task.start(["exec", "01_script"]) }.to output(/bash/).to_stdout
       expect { sysops_task.start(["exec", "01_script"]) }.to output(/ruby/).to_stdout
+    end
+
+    it 'renders the template' do
+      sysops.exec
+      expect(File.read("resources/script.sh")).to match(/echo 'bash'/)
+    end
+
+    it 'makes scripts executable' do
+      sysops.exec
+      expect(File.stat('resources/script.pl').executable?).to be true
+      expect(File.stat('resources/script.rb').executable?).to be true
+      expect(File.stat('resources/script.sh').executable?).to be true
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,12 @@
 require 'fileutils'
-
-require 'kaigara'
+require "tmpdir"
+require "byebug"
 
 FIXTURES_PATH = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures'))
 KAIGARA_GEMPATH = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+$: << File.join(KAIGARA_GEMPATH, "lib")
+
+require 'kaigara'
 
 RSpec.configure do |config|
   config.before(:all, &:silence_output)
@@ -32,4 +35,19 @@ def enable_output
   $stdout = @original_stdout
   @original_stderr = nil
   @original_stdout = nil
+end
+
+module TmpDirIsolation
+  def self.included(base)
+    base.before(:each) do
+      @old_dir = Dir.pwd
+      @tmp_dir = Dir.mktmpdir
+      Dir.chdir(@tmp_dir)
+    end
+
+    base.after(:each) do
+      Dir.chdir(@old_dir)
+      FileUtils.rm_rf(@tmp_dir)
+    end
+  end
 end

--- a/spec/sysops_spec.rb
+++ b/spec/sysops_spec.rb
@@ -1,6 +1,6 @@
 require_relative 'spec_helper'
 
-describe Kaigara::Sysops do
+describe Kaigara::Sysops, :unit do
   include TmpDirIsolation
 
   let(:sysops) { Kaigara::Sysops.new }

--- a/spec/sysops_spec.rb
+++ b/spec/sysops_spec.rb
@@ -1,17 +1,13 @@
-require 'spec_helper'
+require_relative 'spec_helper'
 
 describe Kaigara::Sysops do
+  include TmpDirIsolation
+
   let(:sysops) { Kaigara::Sysops.new }
 
   before(:each) do
-    @src_home = Dir.pwd
     sysops.create 'testops'
     Dir.chdir 'testops'
-  end
-
-  after(:each) do
-    Dir.chdir(@src_home)
-    FileUtils.rm_r 'testops'
   end
 
   describe 'create' do

--- a/spec/sysops_spec.rb
+++ b/spec/sysops_spec.rb
@@ -71,36 +71,4 @@ describe Kaigara::Sysops, :unit do
     end
 
   end
-
-  describe 'script' do
-    before(:each) do
-      FileUtils.cp(fixture("refops/metadata.rb"), ".")
-      FileUtils.cp(fixture("refops/operations/01_script.rb"), "operations/")
-      FileUtils.cp(fixture("refops/resources/script.pl.erb"), "resources/")
-      FileUtils.cp(fixture("refops/resources/script.rb.erb"), "resources/")
-      FileUtils.cp(fixture("refops/resources/script.sh.erb"), "resources/")
-    end
-
-    it 'should render the template' do
-      sysops.exec
-      expect(File.read("resources/script.sh")).to match(/echo 'bash'/)
-    end
-
-    it 'should make the script executable' do
-      sysops.exec
-      expect(File.stat('resources/script.sh').executable?).to be true
-    end
-
-    it 'should execute each script' do
-      expect { sysops.exec }.to output(/perl/).to_stdout
-      expect { sysops.exec }.to output(/bash/).to_stdout
-      expect { sysops.exec }.to output(/ruby/).to_stdout
-    end
-
-    after(:each) do
-      FileUtils.rm Dir["resources/*"]
-      FileUtils.rm Dir["operations/*"]
-      FileUtils.rm "metadata.rb"
-    end
-  end
 end


### PR DESCRIPTION
- Add operations tests
  Moved tests of operations execution to operations_spec.rb

- Tag tests to be able to run only specific tests, for example:
  rspec --tag integration run only integration tests)
  rspec --tag unit (run only unit tests)
  rspec --tag ~integration (exclude integration tests)
